### PR TITLE
feat: Add option to skip session selection in ballot application

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,6 +16,9 @@ Sessions = "All"
 # Sessions = ["昼公演"]
 # Sessions = ["昼公演", "夜公演"]
 # Sessions = "All"
+# Or you can specify if the balloter must skip the session selection
+# SkipSessionSelection = true
+# Sessions = "Day.2"
 
 Renban = 1 # or { name = "ふううばる", address = "mail@address.com" }
 # If you don't want to ballot with a renban you can either comment the line


### PR DESCRIPTION
This pull request introduces the ability to skip session selection during the ballot process by adding a new configuration option and updating the relevant functions to handle this new option.

### Configuration Changes:
* [`config.toml`](diffhunk://#diff-28043ff911f28a5cb5742f7638363546311225a63eabc365af5356c70d4deb77R19-R21): Added a new configuration option `SkipSessionSelection` to allow skipping the session selection step.

### Code Changes:
* `main.py`: 
  * Updated the `apply_for_single_session` function to accept a `skip_session_selection` parameter and modified the logic to skip session selection if this parameter is set.
  * Modified the `start_single_ballot_process` function to retrieve the `SkipSessionSelection` configuration and use it to control session selection logic. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R337-R341) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R350-R357) [[3]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L365-R372)